### PR TITLE
Rename the set to reflect the repository name

### DIFF
--- a/sets.conf
+++ b/sets.conf
@@ -1,4 +1,4 @@
-[ixit sets]
+[enlightenment-live sets]
 class = portage.sets.files.StaticFileSet
 multiset = true
 directory = ${repository:enlightenment-live}/sets/


### PR DESCRIPTION
To make everything 100% consistent I renamed the package set from ixit to enlightenment-live.