### PR TITLE
Handling DRM and gstreamer options

### DIFF
--- a/dev-libs/efl/efl-9999.ebuild
+++ b/dev-libs/efl/efl-9999.ebuild
@@ -19,6 +19,7 @@ SLOT="0"
 IUSE="avahi +bmp connman example dds debug doc drm +eet egl eo fbcon +fontconfig fribidi gif gles glib gnutls gstreamer +harfbuzz hyphen +ibus +ico jpeg2k json libuv luajit nls opengl pdf pixman physics +ppm postscript +psd pulseaudio raw scim sdl sound ssl +svg systemd tga tiff tslib unwind v4l vlc vnc test wayland +webp +X xcf +xim xine xpresent xpm"
 
 REQUIRED_USE="
+	drm? ( wayland )
 	fbcon? ( !tslib )
 	gles? (
 		|| ( X wayland )

--- a/dev-libs/efl/efl-9999.ebuild
+++ b/dev-libs/efl/efl-9999.ebuild
@@ -170,7 +170,7 @@ src_configure() {
 
 	local emesonargs=(
 		-Demotion-generic-loaders-disabler=$(usex vlc '' vlc)
-		-Demotion-loaders-disabler=libvlc,gstreamer,$(usex gstreamer '' 'gstreamer1,')$(usex xine '' xine)
+		-Demotion-loaders-disabler=libvlc,gstreamer$(usex gstreamer '' ',gstreamer1')$(usex xine '' ',xine')
 
 		-Dlua-interpreter=$(usex luajit luajit lua)
 		-Dbindings=$(usex luajit 'luajit,' '')cxx


### PR DESCRIPTION
Made a few changes:
- DRM use flag is now dependant on Wayland
- gstreamer in emotion-loaders-disabler is being handled correctly.