### PR TITLE
Fixed USE flag consolekit for entrance

### DIFF
--- a/x11-misc/entrance/entrance-9999.ebuild
+++ b/x11-misc/entrance/entrance-9999.ebuild
@@ -40,6 +40,7 @@ src_configure() {
 		-Dnls=$(usex nls true false)
 		-Dpam=$(usex pam true false)
 		-Dlogind=$(usex systemd true false)
+		-Dconsolekit=$(usex consolekit true false)
 	)
 	meson_src_configure
 }


### PR DESCRIPTION
This change correcting build "entrance" with disabled USE-flag "consolekit"