### PR TITLE
efl: fix postscript dependency in generic loaders

### DIFF
--- a/dev-libs/efl/efl-9999.ebuild
+++ b/dev-libs/efl/efl-9999.ebuild
@@ -255,6 +255,9 @@ src_configure() {
 	if use !ppm ; then
 		combined_evas_loaders="${combined_evas_loaders}${combined_evas_loaders:+,}pmaps"
 	fi
+	if use !postscript; then
+		combined_evas_loaders="${combined_evas_loaders}${combined_evas_loaders:+,}ps"
+	fi
 
 	emesonargs+=(
 		-Decore-imf-loaders-disabler="$combined_imf"


### PR DESCRIPTION
Evas loaders uses a default-on configuration, so disabling postscript has to explicitly disable the "ps" flag for meson.
Otherwise the build will fail when "libspectre", the postscript-dependency, is not available.